### PR TITLE
Don't use explicit rockchip include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SOURCE_FILES drm.c
 				rtp_frame.c
 				main.c)
 
-include_directories("/usr/include/libdrm" "/usr/local/include/rockchip" "/usr/include/cairo")
+include_directories("/usr/include/libdrm" "/usr/include/cairo")
 
 add_executable(fpvue ${SOURCE_FILES})
 target_link_libraries(fpvue rockchip_mpp pthread drm cairo)

--- a/drm.c
+++ b/drm.c
@@ -15,7 +15,7 @@
 #include <drm_fourcc.h>
 #include <cairo.h>
 #include <pthread.h>
-#include <rk_mpi.h>
+#include <rockchip/rk_mpi.h>
 #include <assert.h>
 
 int modeset_open(int *out, const char *node)

--- a/drm.h
+++ b/drm.h
@@ -22,7 +22,7 @@
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>
 #include <pthread.h>
-#include <rk_mpi.h>
+#include <rockchip/rk_mpi.h>
 #include <assert.h>
 
 struct drm_object {

--- a/main.c
+++ b/main.c
@@ -27,7 +27,7 @@
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>
 #include <linux/videodev2.h>
-#include <rk_mpi.h>
+#include <rockchip/rk_mpi.h>
 
 #include "drm.h"
 #include "osd.h"


### PR DESCRIPTION
It helps to build app on standard Rockchip based board without modifying CMakeLists.txt

Tested on Orange Pi 5 Plus:

```
orangepi@orangepi5plus:~/git/FPVue_rk$ cat /etc/*-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.3 LTS"
# PLEASE DO NOT EDIT THIS FILE
BOARD=orangepi5plus
BOARD_NAME="Orange Pi 5 Plus"
BOARDFAMILY=rockchip-rk3588
BUILD_REPOSITORY_URL=https://github.com/orangepi-xunlong/orangepi-build
BUILD_REPOSITORY_COMMIT=409075093-dirty
```