### PR TITLE
Add more debugging options to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,20 @@ set(SOURCE_FILES drm.c
 
 include_directories("/usr/include/libdrm" "/usr/include/cairo")
 
-add_executable(fpvue ${SOURCE_FILES})
-target_link_libraries(fpvue rockchip_mpp pthread drm m cairo)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} rockchip_mpp pthread drm m cairo)
+
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  set(
+    CMAKE_C_FLAGS
+    "${CMAKE_C_FLAGS} -Werror -fsanitize=undefined -fsanitize=address"
+  )
+  target_link_options(${PROJECT_NAME}
+    BEFORE PUBLIC -fsanitize=undefined PUBLIC -fsanitize=address
+  )
+endif()
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/README.md
+++ b/README.md
@@ -10,33 +10,43 @@ Tested on RK3566 (Radxa Zero 3W) and RK3588s (Orange Pi 5).
 Build on the Rockchip linux system directly.
 
 ## Install dependencies
+
 - rockchip_mpp
+
 ```
 git clone https://github.com/rockchip-linux/mpp.git
-cmake CMakeLists.txt
-make
-sudo make install
+sudo cmake --build build --target install
 ```
-- drm, cairo 
+
+- drm, cairo
+
 ```
 sudo apt install libdrm-dev libcairo-dev
 ```
 
 ## Build Instructions
-```
-cmake CMakeLists.txt
-make
-```
 
-### Run
+Build and run application in production environment:
 
 ```
+cmake -B build
+sudo cmake --build build --target install
+fpvue
+```
+
+Build and run application for debugging purposes:
+
+```
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
 ./fpvue
 ```
 
+### Usage
+
 Show command line options:
 ```
-./fpvue --help
+fpvue --help
 ```
 
 ### Known issues


### PR DESCRIPTION
This will help to debug memory leaks and finding unbound memory access like:

```
$ ./build/fpvue 
ignoring unused connector 197
ignoring unused connector 211
ignoring unused connector 225
Display skipped -1094795586 frame.
listening on socket 5600
/home/orangepi/git/FPVue_rk/drm.c:126:28: runtime error: member access within misaligned address 0xbebebebebebebebe for type 'struct drmModeObjectProperties', which requires 8 byte alignment
0xbebebebebebebebe: note: pointer points here
<memory cannot be printed>
AddressSanitizer:DEADLYSIGNAL
=================================================================
==3341==ERROR: AddressSanitizer: SEGV on unknown address 0x17d7d7e7d7d7d7d7 (pc 0x005582486678 bp 0x007fa4bcdd10 sp 0x007fa4bcdd10 T4)
==3341==The signal is caused by a READ memory access.
    #0 0x5582486678 in set_drm_object_property /home/orangepi/git/FPVue_rk/drm.c:126
    #1 0x55824a71e0 in __DISPLAY_THREAD__ /home/orangepi/git/FPVue_rk/main.c:269
    #2 0x7fadf1d5c4  (/lib/aarch64-linux-gnu/libc.so.6+0x7d5c4)
    #3 0x7fadf85d98  (/lib/aarch64-linux-gnu/libc.so.6+0xe5d98)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/orangepi/git/FPVue_rk/drm.c:126 in set_drm_object_property
Thread T4 created by T0 here:
    #0 0x7faeb26188 in __interceptor_pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:216
    #1 0x55824aa764 in main /home/orangepi/git/FPVue_rk/main.c:560
    #2 0x7fadec73f8  (/lib/aarch64-linux-gnu/libc.so.6+0x273f8)
    #3 0x7fadec74c8 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x274c8)
    #4 0x5582484f6c in _start (/home/orangepi/git/FPVue_rk/build/fpvue+0x34f6c)

==3341==ABORTING
```