### PR TITLE
Bitrate fix

### DIFF
--- a/osd.c
+++ b/osd.c
@@ -108,9 +108,9 @@ void modeset_paint_buffer(struct modeset_buf *buf) {
 			}
 			avg_bw = avg_bw / avg_cnt;
 			if (avg_bw < 1000) {
-				sprintf(msg, "%.2f Kbps", avg_bw / 125 );
+				sprintf(msg, "%.2f Kbps", avg_bw / 75 );
 			} else {
-				sprintf(msg, "%.2f Mbps", avg_bw / 125000 );
+				sprintf(msg, "%.2f Mbps", avg_bw / 75000 );
 			}
 			row_count++;
 			cairo_set_source_surface (cr, net_icon, osd_x+22, stats_top_margin+row_count*stats_row_height-19);


### PR DESCRIPTION
This small fix fixes the incorrect video bitrate.
By default the Majestic has 1200 Bytes NAL Size stream. This means every pkt received by Radxa is 1200 Bytes, NOT 1024 Bytes. So for example on MCS3 if we have a video stream of 2700 pkt/s the video bitrate is: (2700*1200*8)/1024/1024=25Mbps
To confirm the video stream run wfb-cli gs on the Radxa to monitor the packets received.